### PR TITLE
use_data has been moved to the usethis package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,6 @@ Imports:
     utils
 Suggests: knitr,
     rmarkdown,
-    devtools
+    usethis
 VignetteBuilder: knitr
 RoxygenNote: 6.0.1

--- a/R/make_trial_dataset.R
+++ b/R/make_trial_dataset.R
@@ -28,5 +28,5 @@ make_trial_dataset = function() {
 
   # Summarize results in data.frame and save
   trial <- data.frame(drug, resistance, prebiom, postbiom)
-  devtools::use_data(trial)
+  usethis::use_data(trial)
 }


### PR DESCRIPTION
`use_data()` was deprecated in devtools 2.0.0 and has now been removed
in devtools 2.1.0. Instead you can use the version in the usethis
package.